### PR TITLE
Update Dockerfile to use Eclipse Temurin 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:14-jre-slim
+FROM eclipse-temurin:11-jre
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- Updated Dockerfile to use Eclipse Temurin 11 JRE instead of OpenJDK 14
- Provides better performance and security with a stable LTS Java version
- Aligns with modern containerization best practices

## Test plan
- Verify Docker image builds successfully with new base image
- Test application startup and functionality in container
- Ensure all existing features work correctly with Java 11

🤖 Generated with [Claude Code](https://claude.ai/code)